### PR TITLE
Fixed update methods in topology.py to take molecule, and fixed calls…

### DIFF
--- a/scripts/molecular_mechanics/mmlib/molecule.py
+++ b/scripts/molecular_mechanics/mmlib/molecule.py
@@ -613,10 +613,10 @@ class Molecule:
 
   def UpdateInternals(self):
     """Update current values of internal degrees of freedom."""
-    topology.UpdateBonds(self.bonds)
-    topology.UpdateAngles(self.angles)
-    topology.UpdateTorsions(self.torsions)
-    topology.UpdateOutofplanes(self.outofplanes)
+    topology.UpdateBonds(self)
+    topology.UpdateAngles(self)
+    topology.UpdateTorsions(self)
+    topology.UpdateOutofplanes(self)
 
   def GetTemperature(self):
     """Calculate instantaneous kinetic temperature [K] of system."""

--- a/scripts/molecular_mechanics/mmlib/topology.py
+++ b/scripts/molecular_mechanics/mmlib/topology.py
@@ -214,7 +214,7 @@ def GetNonints(bonds, angles, torsions):
   return nonints
 
 
-def UpdateBonds(bonds):
+def UpdateBonds(mol):
   """Update all bond lengths [Angstrom] within a molecule object.
   
   Args:
@@ -228,7 +228,7 @@ def UpdateBonds(bonds):
     mol.bond_graph[bond.at2][bond.at1] = bond.r_ij
 
 
-def UpdateAngles(angles):
+def UpdateAngles(mol):
   """Update all bond angles [degrees] within a molecule object.
   
   Args:
@@ -243,7 +243,7 @@ def UpdateAngles(angles):
     angle.a_ijk = geomcalc.GetAijk(c1, c2, c3, r12, r23)
 
 
-def UpdateTorsions(torsions):
+def UpdateTorsions(mol):
   """Update all torsion angles [degrees] within a molecule object.
   
   Args:
@@ -260,7 +260,7 @@ def UpdateTorsions(torsions):
     torsion.t_ijkl = geomcalc.GetTijkl(c1, c2, c3, c4, r12, r23, r34)
 
 
-def UpdateOutofplanes(outofplanes):
+def UpdateOutofplanes(mol):
   """Update all outofplane angles [degrees] within a molecule object.
   
   Args:


### PR DESCRIPTION
… to pass in molecule.

This fixes errors of the following type, discovered when trying to run mc.py

```
python3 mc.py ../../input/mc/he20.mc 
0/20000 confs as of 12:36:14
Traceback (most recent call last):
  File "mc.py", line 27, in <module>
    sim.Run()
  File "/Users/jialincheoh/computational_chemistry/scripts/molecular_mechanics/mmlib/simulate.py", line 410, in Run
    self._DispCoords(self.rand_disp)
  File "/Users/jialincheoh/computational_chemistry/scripts/molecular_mechanics/mmlib/simulate.py", line 453, in _DispCoords
    self.mol.UpdateInternals()
  File "/Users/jialincheoh/computational_chemistry/scripts/molecular_mechanics/mmlib/molecule.py", line 618, in UpdateInternals
    topology.UpdateTorsions(self.torsions)
  File "/Users/jialincheoh/computational_chemistry/scripts/molecular_mechanics/mmlib/topology.py", line 252, in UpdateTorsions
    for torsion in mol.torsions:
NameError: name 'mol' is not defined
```