### PR TITLE
ensure that the Usage: always prints the correct name of a script

### DIFF
--- a/scripts/geometry_analysis/angles.py
+++ b/scripts/geometry_analysis/angles.py
@@ -51,7 +51,7 @@ def get_geom(xyz_file_name):
 # input syntax and usage warnings
 def get_inputs():
     if (not len(sys.argv) == 2):
-        print('Usage: {} XYZ_FILE\n'.format(sys.argv[0]))
+        print('Usage: %s XYZ_FILE\n' % (sys.argv[0]))
         print('  XYZ_FILE: coordinates of target molecule\n')
         sys.exit()
     else:

--- a/scripts/geometry_analysis/angles.py
+++ b/scripts/geometry_analysis/angles.py
@@ -51,7 +51,7 @@ def get_geom(xyz_file_name):
 # input syntax and usage warnings
 def get_inputs():
     if (not len(sys.argv) == 2):
-        print('Usage: angles.py XYZ_FILE\n')
+        print('Usage: {} XYZ_FILE\n'.format(sys.argv[0]))
         print('  XYZ_FILE: coordinates of target molecule\n')
         sys.exit()
     else:

--- a/scripts/geometry_analysis/bonds.py
+++ b/scripts/geometry_analysis/bonds.py
@@ -47,7 +47,7 @@ def get_geom(xyz_file_name):
 # input syntax and usage warnings
 def get_inputs():
     if (not len(sys.argv) == 2):
-        print('Usage: bonds.py XYZ_FILE\n')
+        print('Usage: {} XYZ_FILE\n'.format(sys.argv[0]))
         print('  XYZ_FILE: coordinates of target molecule\n')
         sys.exit()
     else:

--- a/scripts/geometry_analysis/bonds.py
+++ b/scripts/geometry_analysis/bonds.py
@@ -47,7 +47,7 @@ def get_geom(xyz_file_name):
 # input syntax and usage warnings
 def get_inputs():
     if (not len(sys.argv) == 2):
-        print('Usage: {} XYZ_FILE\n'.format(sys.argv[0]))
+        print('Usage: %s XYZ_FILE\n' % (sys.argv[0]))
         print('  XYZ_FILE: coordinates of target molecule\n')
         sys.exit()
     else:


### PR DESCRIPTION
even if it is renamed.

I watched the video where there was a related but. I see that now all the script print the proper value, but this small patch will ensure that the name is always correctly printed.